### PR TITLE
Components number estimators

### DIFF
--- a/mpest/components_number/methods/elbow.py
+++ b/mpest/components_number/methods/elbow.py
@@ -1,0 +1,54 @@
+"""Module which contains Elbow Method"""
+
+from kneed import KneeLocator
+from sklearn.cluster import KMeans
+
+from mpest.components_number.methods.abstract_estimator import AComponentsNumber
+from mpest.types import Samples
+
+
+class Elbow(AComponentsNumber):
+    """
+    Elbow method with KMeans++
+    -----
+    :param kmax:       int                       — Assumed maximum number of components
+    :param k_init:     int         default: 1   — Number of times the KMeans is run
+    :param k_max_iter: int         default: 300  — Maximum number of iterations in KMeans
+    :random_state:     int | None  default: None — Determines random generation for KMeans
+    """
+
+    def __init__(
+        self,
+        kmax: int,
+        k_init: int = 1,
+        k_max_iter: int = 300,
+        random_state: int | None = None,
+    ) -> None:
+        self.kmax = kmax
+        self.k_init = k_init
+        self.k_max_iter = k_max_iter
+        self.random_state = random_state
+
+    @property
+    def name(self) -> str:
+        return "Elbow"
+
+    def estimate(self, sample: Samples) -> int:
+
+        sample = sample.reshape(-1, 1)
+        k_range = range(1, self.kmax + 2)  # possible components: [2, kmax]
+        wcss = []
+
+        for k in k_range:
+            kmeans_elbow = KMeans(
+                n_clusters=k,
+                max_iter=self.k_max_iter,
+                init="k-means++",
+                n_init=self.k_init,
+                random_state=self.random_state,
+            ).fit(sample)
+            wcss.append(kmeans_elbow.inertia_)
+
+        knee = KneeLocator(k_range, wcss, curve="convex", direction="decreasing").elbow
+
+        return knee

--- a/mpest/components_number/methods/peaks.py
+++ b/mpest/components_number/methods/peaks.py
@@ -1,0 +1,39 @@
+"""Module which contains Peaks Method"""
+
+from math import ceil
+
+import numpy as np
+from scipy.signal import find_peaks
+
+from mpest.components_number.methods.abstract_estimator import AComponentsNumber
+from mpest.types import Samples
+
+
+class Peaks(AComponentsNumber):
+    """Peaks Method with Emperical Density"""
+
+    @property
+    def name(self) -> str:
+        return "Peaks"
+
+    def estimate(self, sample: Samples) -> int:
+        """
+        Doanes fromula to determinate numbers of bins
+        #  nbins = 1 + log2(n) + log2(1 + |skewness| / sg1)
+        #  sg1 = √(6.0 * (n - 2.0) / ((n + 1.0) * (n + 3.0)))
+        """
+
+        n = sample.size
+        sg1 = np.sqrt(6.0 * (n - 2.0) / ((n + 1.0) * (n + 3.0)))
+        skew = np.mean(((sample - np.mean(sample)) / np.std(sample)) ** 3)
+
+        nbins = ceil(1 + np.log2(n) + np.log2(1 + abs(skew) / sg1))
+
+        #  Emperical Density
+        hist = np.histogram(sample, bins=nbins, density=True)[0]
+        hist = np.concatenate((np.zeros(1), hist, np.zeros(1)))
+
+        #  Peaks counting
+        peaks, _ = find_peaks(hist)
+        peaks_count = len(peaks)
+        return peaks_count

--- a/mpest/components_number/methods/silhouette.py
+++ b/mpest/components_number/methods/silhouette.py
@@ -1,0 +1,53 @@
+"""Module which contains Silhouette Method"""
+
+from sklearn.cluster import KMeans
+from sklearn.metrics import silhouette_score
+
+from mpest.components_number.methods.abstract_estimator import AComponentsNumber
+from mpest.types import Samples
+
+
+class Silhouette(AComponentsNumber):
+    """
+    Silhouette method with KMeans++
+    -----
+    :param kmax:       int                       — Assumed maximum number of components
+    :param k_init:     int         default: 1   — Number of times the KMeans is run
+    :param k_max_iter: int         default: 300  — Maximum number of iterations in KMeans
+    :random_state:     int | None  default: None — Determines random generation for KMeans
+    """
+
+    def __init__(
+        self,
+        kmax: int,
+        k_init: int = 1,
+        k_max_iter: int = 300,
+        random_state: int | None = None,
+    ) -> None:
+        self.kmax = kmax
+        self.k_init = k_init
+        self.k_max_iter = k_max_iter
+        self.random_state = random_state
+
+    @property
+    def name(self) -> str:
+        return "Silhouette"
+
+    def estimate(self, sample: Samples) -> int:
+        sample = sample.reshape(-1, 1)
+        k_range = range(2, self.kmax + 1)  # possible components: [2, kmax]
+        silhouettes = []
+
+        for k in k_range:
+            kmeans_silhouette = KMeans(
+                n_clusters=k,
+                max_iter=self.k_max_iter,
+                init="k-means++",
+                n_init=self.k_init,
+                random_state=self.random_state,
+            ).fit(sample)
+            silhouettes.append(silhouette_score(sample, kmeans_silhouette.labels_))
+
+        optimal_k = silhouettes.index(max(silhouettes)) + 2
+
+        return optimal_k

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ scikit-learn
 scipy
 seaborn
 tqdm
+kneed

--- a/tests/tests_components_number/components_num_utils.py
+++ b/tests/tests_components_number/components_num_utils.py
@@ -1,0 +1,21 @@
+import numpy as np
+from mpest.components_number.methods import AComponentsNumber
+from mpest import Distribution, MixtureDistribution
+from mpest.models import AModelWithGenerator
+
+
+def run_test(models: list[AModelWithGenerator], params: list[list[float]],
+             prior_probabilities: list[float], size: int, method: AComponentsNumber) -> int:
+
+    np.random.seed(42)
+
+    base_mixture_distribution = MixtureDistribution.from_distributions(
+        [
+            Distribution(model, param) for model, param in zip(models, params)
+        ],
+        prior_probabilities
+    )
+
+    x = base_mixture_distribution.generate(size)
+    result = method.estimate(x)
+    return result

--- a/tests/tests_components_number/test_elbow.py
+++ b/tests/tests_components_number/test_elbow.py
@@ -1,0 +1,69 @@
+import pytest
+
+from tests.tests_components_number.components_num_utils import run_test
+from mpest.components_number.methods import Elbow
+from mpest.models import (
+    ExponentialModel,
+    GaussianModel,
+    WeibullModelExp,
+)
+
+
+@pytest.mark.parametrize(
+    "models, params, prior, size, kmax",
+    [
+        (
+            [WeibullModelExp(), GaussianModel(), GaussianModel()],
+            [[1.0, 0.5], [5.0, 1.0], [15.0, 2.0]],
+            [0.33, 0.33, 0.33],
+            200,
+            15
+        ),
+        (
+            [GaussianModel(), GaussianModel()],
+            [[5.0, 2.0], [15.0, 2.0]],
+            [0.6, 0.4],
+            500,
+            15
+        ),
+        (
+            [WeibullModelExp(), GaussianModel(), ExponentialModel(), WeibullModelExp()],
+            [[11.0, 2.5], [5.0, 3.0], [0.25], [18.0, 2.0]],
+            [0.2, 0.2, 0.4, 0.2],
+            1000,
+            20
+        ),
+    ]
+)
+def test_correct_estimating(models, params, prior, size, kmax):
+    assert run_test(models, params, prior, size, Elbow(kmax, random_state=42)) == len(models)
+
+
+@pytest.mark.parametrize(
+    "models, params, prior, size, kmax",
+    [
+        (
+            [GaussianModel(), GaussianModel(), GaussianModel()],
+            [[5.0, 2.0], [10.0, 2.0], [15.0, 2.0]],
+            [6.0, 2.0, 2.0],
+            200,
+            20,
+        ),
+        (
+            [GaussianModel(), WeibullModelExp()],
+            [[5.0, 2.0], [7.0, 3.0]],
+            [0.5, 0.5],
+            500,
+            15
+        ),
+        (
+            [ExponentialModel(), WeibullModelExp(), WeibullModelExp()],
+            [[0.5], [6.0, 5.0], [7.0, 5.0]],
+            [0.1, 0.3, 0.6],
+            1000,
+            15
+        )
+    ]
+)
+def test_incorrect_estimating(models, params, prior, size, kmax):
+    assert run_test(models, params, prior, size, Elbow(kmax, random_state=42)) != len(models)

--- a/tests/tests_components_number/test_peaks.py
+++ b/tests/tests_components_number/test_peaks.py
@@ -1,0 +1,63 @@
+import pytest
+
+from tests.tests_components_number.components_num_utils import run_test
+from mpest.components_number.methods import Peaks
+from mpest.models import (
+    ExponentialModel,
+    GaussianModel,
+    WeibullModelExp,
+)
+
+
+@pytest.mark.parametrize(
+    "models, params, prior, size",
+    [
+        (
+            [GaussianModel()],
+            [[5.0, 2.0]],
+            [1.0],
+            200
+        ),
+        (
+            [WeibullModelExp(), WeibullModelExp(), WeibullModelExp()],
+            [[5.0, 2.0], [7.0, 1.0], [11.0, 3.0]],
+            [0.33, 0.33, 0.33],
+            500
+        ),
+        (
+            [WeibullModelExp(), GaussianModel(), WeibullModelExp()],
+            [[4.0, 2.0], [7.5, 2.5], [10.0, 4.0]],
+            [0.2, 0.4, 0.2],
+            1000
+        )
+    ]
+)
+def test_correct_estimating(models, params, prior, size):
+    assert run_test(models, params, prior, size, Peaks()) == len(models)
+
+
+@pytest.mark.parametrize(
+    "models, params, prior, size",
+    [
+        (
+            [WeibullModelExp(), WeibullModelExp(), ExponentialModel()],
+            [[10.0, 1.0], [4.0, 6.0], [3.5]],
+            [0.2, 0.4, 0.4],
+            200,
+        ),
+        (
+            [ExponentialModel(), ExponentialModel(), GaussianModel(), GaussianModel()],
+            [[0.5], [3.5], [9.0, 0.5], [3.0, 6.0]],
+            [0.1, 0.2, 0.4, 0.3],
+            5000,
+        ),
+        (
+            [GaussianModel(), WeibullModelExp()],
+            [[3.0, 1.5], [7.0, 2.0]],
+            [0.7, 0.3],
+            1000,
+        )
+    ]
+)
+def test_incorrect_estimating(models, params, prior, size):
+    assert run_test(models, params, prior, size, Peaks()) != len(models)

--- a/tests/tests_components_number/test_silhouette.py
+++ b/tests/tests_components_number/test_silhouette.py
@@ -1,0 +1,69 @@
+import pytest
+
+from tests.tests_components_number.components_num_utils import run_test
+from mpest.components_number.methods import Silhouette
+from mpest.models import (
+    ExponentialModel,
+    GaussianModel,
+    WeibullModelExp,
+)
+
+
+@pytest.mark.parametrize(
+    "models, params, prior, size, kmax",
+    [
+        (
+            [WeibullModelExp(), GaussianModel()],
+            [[2.0, 10.0], [5.0, 1.0]],
+            [0.6, 0.4],
+            200,
+            10
+        ),
+        (
+            [GaussianModel(), GaussianModel(), GaussianModel()],
+            [[5.0, 3.0], [2.0, 6.0], [1.0, 0.5]],
+            [0.3, 0.3, 0.3],
+            500,
+            10
+        ),
+        (
+            [ExponentialModel(), GaussianModel(), GaussianModel(), GaussianModel()],
+            [[0.5], [1.0, 0.5], [3.0, 10.0], [5.0, 1.0]],
+            [0.5, 0.3, 0.1, 0.1],
+            500,
+            10
+        ),
+    ]
+)
+def test_correct_estimating(models, params, prior, size, kmax):
+    assert run_test(models, params, prior, size, Silhouette(kmax, random_state=42)) == len(models)
+
+
+@pytest.mark.parametrize(
+    "models, params, prior, size, kmax",
+    [
+        (
+            [WeibullModelExp(), WeibullModelExp(), ExponentialModel()],
+            [[1.0, 2.0], [5.0, 1.0], [1.0]],
+            [0.33, 0.33, 0.33],
+            200,
+            10
+        ),
+        (
+            [ExponentialModel()],
+            [[0.5]],
+            [1.0],
+            500,
+            10
+        ),
+        (
+            [ExponentialModel(), ExponentialModel(), WeibullModelExp()],
+            [[0.5], [3.0], [3.0, 0.5]],
+            [0.4, 0.5, 0.1],
+            1000,
+            10
+        )
+    ]
+)
+def test_incorrect_estimating(models, params, prior, size, kmax):
+    assert run_test(models, params, prior, size, Silhouette(kmax, random_state=42)) != len(models)


### PR DESCRIPTION
The module on estimating the number of components in a mixture of distributions includes:

- Elbow method (with K-Means++)
- Sihouette method (with K-Means++)
- Peaks method (with emperical density)
- XMeans method (based on classic EM-algorithm)
- Information criterion (AIC, BIC)